### PR TITLE
bug fixes Identified during integration - 1

### DIFF
--- a/src/DateRangeControl.tsx
+++ b/src/DateRangeControl.tsx
@@ -110,7 +110,7 @@ export class DateRangeControl extends React.Component<
             months: Array.from({ length: this.numOfMonths }, (_, i) =>
                 addMonths(startDate || thisMonth, i)
             ),
-            selectionActive: false
+            selectionActive: startDate && !endDate ? true : false
         };
     }
 
@@ -123,7 +123,7 @@ export class DateRangeControl extends React.Component<
                 startDate,
                 endDate,
                 months: Array.from({ length: this.numOfMonths }, (_, i) =>
-                    addMonths(startDate || state.months[0], i)
+                    addMonths(state.months[0], i)
                 )
             };
         });


### PR DESCRIPTION
1. When Start Date is passed as props, mouse-hover on Date, active range selection is not coming and startDate is resetting

2. If StartDate is passed by props and selecting EndDate in 2nd month of Range Picker view, Calendar months changes and update the view with Next month.

Please observe all the issues in below GIF/Video
Video - [https://drive.google.com/open?id=1jv42vFxFJwYsiVOwmwafdaLzfGoaQS65](https://drive.google.com/open?id=1jv42vFxFJwYsiVOwmwafdaLzfGoaQS65)

![screen-capture (1)](https://user-images.githubusercontent.com/9301669/68290757-80985d80-00ae-11ea-99e9-30cce056a592.gif)

